### PR TITLE
Refine error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options:
   --logLevel        Logging level: error, warn, info or verbose.
                                                                [default: "info"]
 ```
-When running with `--outputFile` set, logging information is shown directly otherwise it goes to `csvparserprice.log`.
+When running with `--outputFile` set, logging information is shown directly otherwise it goes to `csvparserprice.log` with the exception of fatal errors.
 
 ### JS
 ```js
@@ -64,6 +64,7 @@ csvParserPrice.parse(
   fs.createWriteStream('./output.json')
 );
 ```
+Errors on the level `error` come from events that are fatal and thus stop the stream of data.
 
 ## Configuration
 `CsvParserPrice` accepts three objects as arguments:

--- a/src/cli.js
+++ b/src/cli.js
@@ -101,10 +101,18 @@ Convert commercetools price CSV data to JSON.`
   })
   .argv
 
-const errorHandler = (message) => {
+const errorHandler = (error) => {
   const errorFormatter = new PrettyError()
-  const error = errorFormatter.render(message)
-  log.error('', error)
+  let formattedError
+
+  if (log.level === 'verbose')
+    formattedError = errorFormatter.render(error)
+  else
+    formattedError = error.message
+
+  process.stderr.write(formattedError)
+  process.stderr.write('\n')
+  log.error('', formattedError)
   process.exit(1)
 }
 

--- a/test/integration/cli.spec.js
+++ b/test/integration/cli.spec.js
@@ -97,3 +97,18 @@ test('CLI exits on parsing errors', (t) => {
     }
   )
 })
+
+test('CLI logs stack trace on verbose level', (t) => {
+  const csvFilePath = './test/helpers/sample.csv'
+
+  exec(`${binPath} -p ${PROJECT_KEY} -i ${csvFilePath} --logLevel verbose`,
+    (error, stdout, stderr) => {
+      t.equal(error.code, 1, 'returns process error exit code')
+      t.false(stdout, 'returns no stdout data')
+      t.true(
+        stderr.match(/process._tickCallback/),
+        'returns stack trace error on stderr')
+      t.end()
+    }
+  )
+})


### PR DESCRIPTION
### Description
Fatal errors should always go to `stderr` and the stack trace is expected when logging on a verbose level.