### PR TITLE
fix(cli): properly handle errors during type mapping

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -101,7 +101,7 @@ Convert commercetools price CSV data to JSON.`
   })
   .argv
 
-const errorHandler = (error) => {
+const logError = (error) => {
   const errorFormatter = new PrettyError()
   let formattedError
 
@@ -113,6 +113,14 @@ const errorHandler = (error) => {
   process.stderr.write(formattedError)
   process.stderr.write('\n')
   log.error('', formattedError)
+}
+
+const errorHandler = (errors) => {
+  if (Array.isArray(errors))
+    errors.forEach(logError)
+  else
+    logError(errors)
+
   process.exit(1)
 }
 

--- a/src/map-custom-fields.js
+++ b/src/map-custom-fields.js
@@ -17,8 +17,11 @@ export default (function MapCustomFields () {
   }
 
   function processError (errors, rowIndex, customTypeKey) {
+    if (!Array.isArray(errors))
+      return new Error(`[row ${rowIndex}: ${customTypeKey}] - ${errors}`)
+
     return _.reduce(errors, (prev, curr) => {
-      prev.push(`[row ${rowIndex}: ${customTypeKey}] - ${curr}`)
+      prev.push(new Error(`[row ${rowIndex}: ${customTypeKey}] - ${curr}`))
       return prev
     }, [])
   }
@@ -43,7 +46,7 @@ export default (function MapCustomFields () {
               const _result = this.mapNumber(value)
               if (_result.error)
                 result.error.push(
-                    `[row ${rowIndex}: ${customType.key}] - ${_result.error}`
+                    processError(_result.error, rowIndex, customType.key)
                   )
               if (!_.isUndefined(_result.data))
                 custom.fields[key] = _result.data
@@ -53,7 +56,7 @@ export default (function MapCustomFields () {
               const _result = this.mapBoolean(value)
               if (_result.error)
                 result.error.push(
-                    `[row ${rowIndex}: ${customType.key}] - ${_result.error}`
+                    processError(_result.error, rowIndex, customType.key)
                   )
               if (!_.isUndefined(_result.data))
                 custom.fields[key] = _result.data
@@ -63,7 +66,7 @@ export default (function MapCustomFields () {
               const _result = this.mapMoney(value)
               if (_result.error)
                 result.error.push(
-                    `[row ${rowIndex}: ${customType.key}] - ${_result.error}`
+                    processError(_result.error, rowIndex, customType.key)
                   )
               if (!_.isUndefined(_result.data))
                 custom.fields[key] = _result.data
@@ -96,7 +99,9 @@ export default (function MapCustomFields () {
                   fieldDef.type.name
                 }' type is not supported! Kindly raise an issue for this`
               result.error.push(
-                  `[row ${rowIndex}: ${customType.key}] - ${unsupportedMsg}`
+                  new Error(
+                    `[row ${rowIndex}: ${customType.key}] - ${unsupportedMsg}`
+                  )
                 )
             }
           }

--- a/test/helpers/missing-type-sample.csv
+++ b/test/helpers/missing-type-sample.csv
@@ -1,0 +1,4 @@
+variant-sku,value.currencyCode,value.centAmount,customType
+my-price,EUR,4200,nope-type
+my-price,EUR,4200,nope-type
+my-price2,EUR,4200,nope-type

--- a/test/integration/cli.spec.js
+++ b/test/integration/cli.spec.js
@@ -1,9 +1,11 @@
 import { exec } from 'child_process'
 import fs from 'fs'
+import { SphereClient } from 'sphere-node-sdk'
 import test from 'tape'
 import tmp from 'tmp'
 
 import { version } from '../../package.json'
+import getApiCredentials from '../../src/get-api-credentials'
 
 const binPath = './bin/csvparserprice.js'
 
@@ -12,6 +14,15 @@ if (process.env.CI === 'true')
   PROJECT_KEY = process.env.SPHERE_PROJECT_KEY
 else
   PROJECT_KEY = process.env.npm_config_projectkey
+
+const getApiClient = projectKey => getApiCredentials(projectKey)
+    .then(apiCredentials =>
+      new SphereClient(
+        {
+          config: apiCredentials,
+        },
+      )
+    )
 
 test('CLI help flag', (t) => {
   exec(`${binPath} --help`, (error, stdout, stderr) => {
@@ -83,7 +94,7 @@ test('CLI exits on faulty CSV format', (t) => {
 })
 
 test('CLI exits on parsing errors', (t) => {
-  const csvFilePath = './test/helpers/sample.csv'
+  const csvFilePath = './test/helpers/missing-type-sample.csv'
   const jsonFilePath = tmp.fileSync().name
 
   exec(`${binPath} -p ${PROJECT_KEY} -i ${csvFilePath} -o ${jsonFilePath}`,
@@ -91,15 +102,55 @@ test('CLI exits on parsing errors', (t) => {
       t.equal(error.code, 1, 'returns process error exit code')
       t.false(stdout, 'returns no stdout data')
       t.true(
-        stderr.match(/types\/key=custom-type' not found/),
+        stderr.match(/types\/key=.+ not found/),
         'returns SDK error on stderr')
       t.end()
     }
   )
 })
 
-test('CLI logs stack trace on verbose level', (t) => {
+test('CLI exits on type mapping errors', (t) => {
   const csvFilePath = './test/helpers/sample.csv'
+  const jsonFilePath = tmp.fileSync().name
+
+  const customTypePayload = {
+    key: 'custom-type',
+    name: { nl: 'selwyn' },
+    resourceTypeIds: ['product-price'],
+    fieldDefinitions: [
+      {
+        type: { name: 'Boolean' },
+        name: 'foo',
+        label: { en: 'said the barman' },
+        required: true,
+      },
+    ],
+  }
+
+  getApiClient(PROJECT_KEY)
+    // Clean up and create new custom type
+    .then(client =>
+      client.types.byKey('custom-type').delete(1)
+        // Ignore rejection, we want to create the type either way
+        .catch(() => true)
+        .then(() => client.types.create(customTypePayload))
+    )
+    .then(() => {
+      exec(`${binPath} -p ${PROJECT_KEY} -i ${csvFilePath} -o ${jsonFilePath}`,
+        (error, stdout, stderr) => {
+          t.equal(error.code, 1, 'returns process error exit code')
+          t.false(stdout, 'returns no stdout data')
+          t.true(
+            stderr.match(/row 2: custom-type.+ valid/),
+            'returns mapping error on stderr')
+          t.end()
+        }
+        )
+    })
+})
+
+test('CLI logs stack trace on verbose level', (t) => {
+  const csvFilePath = './test/helpers/missing-type-sample.csv'
 
   exec(`${binPath} -p ${PROJECT_KEY} -i ${csvFilePath} --logLevel verbose`,
     (error, stdout, stderr) => {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -290,7 +290,10 @@ test(`CsvParserPrice::processCustomFields
     t.end()
   }, (error) => {
     t.equal(error.length, 1, 'Errors with data are reported')
-    t.equal(error[0], '[row 2: custom-type] - The number \'2\' isn\'t valid')
+    t.equal(
+      error[0].message,
+      '[row 2: custom-type] - The number \'2\' isn\'t valid'
+    )
     t.end()
   })
 })

--- a/test/map-custom-fields.spec.js
+++ b/test/map-custom-fields.spec.js
@@ -113,7 +113,11 @@ test(`mapCustomFields::parse
     '[row 1: my-category] - The number t isn\'t valid',
   ]
   t.deepEqual(result.data, expected)
-  t.deepEqual(result.error, expectedErrorArray, errMsg)
+  t.deepEqual(
+    result.error.map(error => error.message),
+    expectedErrorArray,
+    errMsg
+  )
   t.end()
 })
 


### PR DESCRIPTION
Put errors in error object and loop over errors in the error handler if
possible.