### PR TITLE
docs(changelog): add initial changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,51 @@
+<a name="1.1.3"></a>
+## [1.1.3](https://github.com/commercetools/csv-parser-price/compare/v1.1.2...v1.1.3) (2016-12-14)
+
+
+### Bug Fixes
+
+* **cli:** properly handle errors during type mapping ([b842b79](https://github.com/commercetools/csv-parser-price/commit/b842b79)), closes [#16](https://github.com/commercetools/csv-parser-price/issues/16)
+* **main:** fix default logger value ([faa8382](https://github.com/commercetools/csv-parser-price/commit/faa8382)), closes [#21](https://github.com/commercetools/csv-parser-price/issues/21)
+
+
+
+<a name="1.1.2"></a>
+## [1.1.2](https://github.com/commercetools/csv-parser-price/compare/v1.1.1...v1.1.2) (2016-12-09)
+
+
+
+<a name="1.1.1"></a>
+## [1.1.1](https://github.com/commercetools/csv-parser-price/compare/v1.1.0...v1.1.1) (2016-12-02)
+
+
+### Bug Fixes
+
+* **user-agent:** search for the SDK package.json from the root ([#10](https://github.com/commercetools/csv-parser-price/issues/10)) ([cf36cce](https://github.com/commercetools/csv-parser-price/commit/cf36cce)), closes [#9](https://github.com/commercetools/csv-parser-price/issues/9)
+
+
+
+<a name="1.1.0"></a>
+# [1.1.0](https://github.com/commercetools/csv-parser-price/compare/v1.0.1...v1.1.0) (2016-11-30)
+
+
+### Features
+
+* **cli:** refine how fatal errors are logged ([8441bd1](https://github.com/commercetools/csv-parser-price/commit/8441bd1)), closes [#11](https://github.com/commercetools/csv-parser-price/issues/11)
+
+
+
+<a name="1.0.1"></a>
+## [1.0.1](https://github.com/commercetools/csv-parser-price/compare/v1.0.0...v1.0.1) (2016-11-25)
+
+
+
+<a name="1.0.0"></a>
+# [1.0.0](https://github.com/commercetools/csv-parser-price/compare/8ff2b6d...v1.0.0) (2016-11-25)
+
+
+### Features
+
+* **project:** release first version ([8ff2b6d](https://github.com/commercetools/csv-parser-price/commit/8ff2b6d))
+
+
+


### PR DESCRIPTION
Add a changelog generated by `conventional-changelog-cli`, for the next release we can automate this with a script.