### PR TITLE
26 sort data early

### DIFF
--- a/test/helpers/sample.csv
+++ b/test/helpers/sample.csv
@@ -1,4 +1,4 @@
 variant-sku,value.currencyCode,value.centAmount,country,customerGroup.groupName,channel.key,validFrom,validUntil,customType,customField.foo,customField.bar,customField.current,customField.name.nl,customField.name.de,customField.status,customField.price,customField.priceset
 my-price,EUR,4200,DE,customer-group,my-channel,2016-11-01T08:01:19+0000,2016-12-01T08:03:10+0000,custom-type,12,nac,true,Selwyn,Merkel,Ready,EUR 1200,"1,2,3,5"
-my-price,EUR,4200,DE,customer-group,my-channel,2016-11-01T08:01:19+0000,2016-12-01T08:03:10+0000,custom-type,12,nac,true,Selwyn,Merkel,Ready,EUR 1200,"1,2,3,5"
 my-price2,EUR,4200,DE,customer-group,my-channel,2016-11-01T08:01:19+0000,2016-12-01T08:03:10+0000,custom-type,12,nac,true,Selwyn,Merkel,Ready,EUR 1200,"1,2,3,5"
+my-price,EUR,4200,DE,customer-group,my-channel,2016-11-01T08:01:19+0000,2016-12-01T08:03:10+0000,custom-type,12,nac,true,Selwyn,Merkel,Ready,EUR 1200,"1,2,3,5"


### PR DESCRIPTION
## Summary
By sorting the data early the reduce function doesn't have to search for prices with the same SKU.

## Description
Simple benchmarks running the CLI with the `time` command:
Before:
```
26000 rows: 15s
15000 rows: 6s
5000 rows: 1.9s
1000 rows: 1s
```

After:
```
26000 rows: 3s
15000 rows: 2.5s
5000 rows: 1.3s
1000 rows: 0.8s
```